### PR TITLE
Create a SubSpec for the Distribution version of the Library

### DIFF
--- a/Cosmos.podspec
+++ b/Cosmos.podspec
@@ -17,4 +17,8 @@ Pod::Spec.new do |s|
   s.screenshots  = "https://raw.githubusercontent.com/exchangegroup/Cosmos/master/graphics/Screenshots/star_screenshot_dark.png"
   s.source_files = "Cosmos/**/*.swift"
   s.ios.deployment_target = "8.0"
+
+  s.subspec 'Distrib' do |ss|
+    ss.source_files = 'Distrib/CosmosDistrib.swift'
+  end
 end


### PR DESCRIPTION
Instead of adding the `CosmosDistrib.swift` file to the XCode project, we may use a **pod**. 

With this pull request, we can start using Cosmos with one line of code: 
`pod 'Cosmos/Distrib'`

Hope it helps :smile: 